### PR TITLE
Change stream creation. Add support for UPE

### DIFF
--- a/pysc/ops.py
+++ b/pysc/ops.py
@@ -48,35 +48,84 @@ def find_corr_mat(stream1: ARRAY, stream2: ARRAY, device):
     ax = None if (tmp := stream1.ndim) == 0 else tmp - 1
 
     a, b, c, d = corr_func(stream1, stream2)
-    a, b, c, d = a.sum(axis=ax), b.sum(axis=ax), c.sum(axis=ax), d.sum(axis=ax)
+
+    a = a.sum(axis=ax, dtype=np.uint32)
+    b = b.sum(axis=ax, dtype=np.uint32)
+    c = c.sum(axis=ax, dtype=np.uint32)
+    d = d.sum(axis=ax, dtype=np.uint32)
 
     return a, b, c, d
 
 
-# TODO: Rewrite separately for np and cp with cp.EWK and numba
+def sc_corr(a: ARRAY, b: ARRAY, c: ARRAY, d: ARRAY, n: int, device):
+    assert device in ("cpu", "gpu")
+
+    if device == "cpu":
+        out = sc_corr_np(a, b, c, d, n)
+    else:
+        out = sc_corr_cp(a, b, c, d, n)
+
+    return out
 
 
-def sc_corr(a: ARRAY, b: ARRAY, c: ARRAY, d: ARRAY, n: int):
-    # assumed ndim >= 2 for a,b,c,d
+# Improves time from 18 us to 1.67 us
+@nvectorize("float32(uint32, uint32, uint32, uint32, int32)", nopython=True)
+def sc_corr_np(a: ARRAY, b: ARRAY, c: ARRAY, d, n: int):
+    out = 1.0 * a * d
+    out -= b * c
 
-    xp = cp.get_array_module(a)
+    if out == 0:
+        return out
 
-    numer = (a * d - b * c).astype(np.float32)
     apb = a + b
     apc = a + c
-    a_b_into_a_c = apb * apc  # Common for both
-    denom1 = n * xp.minimum(apb, apc) - a_b_into_a_c
-    denom2 = a_b_into_a_c - n * xp.maximum(a - d, 0)
+    ab_into_ac = apb * apc
 
-    denom = xp.where(numer > 0, denom1, denom2)
+    if out > 0:
+        denom = n * np.minimum(apb, apc)
+        denom -= ab_into_ac
+    else:
+        denom = ab_into_ac
+        denom -= n * np.maximum(a - d, 0)
 
-    # have to calculate the mask before, as the division is done inplace
-    # not using xp.isnan after the division. Cause if there is still an nan there, we want to catch it in the tests
+    out /= denom
 
-    can_do_division = numer != 0
-    numer[can_do_division] /= denom[can_do_division]
+    return out
 
-    return numer
+
+# Improved time from 565 us to 11.2 us
+sc_corr_cp = cp.ElementwiseKernel(
+    "uint32 a, uint32 b, uint32 c, uint32 d, int32 n",
+    "float32 out",
+    """
+        // Might have to change to unsigned long if required later
+
+        unsigned int apb, apc, ab_into_ac;
+        float denom;
+
+        out = 1.0 * a * d;
+        out -= b*c;
+
+        if(out != 0){
+            apb = a + b;
+            apc = a + c;
+            ab_into_ac = apb * apc;
+
+            if(out > 0){
+                denom = n * min(apb, apc);
+                denom -= ab_into_ac;
+            }
+            else{
+                denom = ab_into_ac;
+                denom -= n * max(a - d, 0);
+            }
+
+            out /= denom;
+        }
+    """,
+    "sc_corr_cp",
+    reduce_dims=True,
+)
 
 
 def pearson(a: ARRAY, b: ARRAY, c: ARRAY, d: ARRAY):

--- a/pysc/stream.py
+++ b/pysc/stream.py
@@ -42,6 +42,8 @@ class SCStream:
         self.__stream: ARRAY = None
         self.__generate_stream(inp)
 
+        cp.get_default_memory_pool().free_all_blocks()
+
     def __generate_stream(self, inp):
         if not (isinstance(inp, np.ndarray) or isinstance(inp, cp.ndarray)):
             inp = self.xp.array(inp, dtype=np.float32)[None]

--- a/pysc/stream.py
+++ b/pysc/stream.py
@@ -89,7 +89,7 @@ class SCStream:
 
         a, b, c, d = find_corr_mat(self.__stream, other.__stream, self.__device)
 
-        scc = sc_corr(a, b, c, d, self.__precision)
+        scc = sc_corr(a, b, c, d, self.__precision, self.__device)
         pearson_corr = pearson(a, b, c, d)
 
         return scc, pearson_corr

--- a/pysc/stream.py
+++ b/pysc/stream.py
@@ -4,7 +4,7 @@ from typing import Tuple
 import cupy as cp
 import numpy as np
 
-from pysc.ops import find_corr_mat, pearson, sc_corr
+from pysc.ops import find_corr_mat, pearson_corr, sc_corr
 from pysc.utils import ARRAY, createProbabilityStream, npStream
 
 
@@ -90,7 +90,7 @@ class SCStream:
         a, b, c, d = find_corr_mat(self.__stream, other.__stream, self.__device)
 
         scc = sc_corr(a, b, c, d, self.__precision, self.__device)
-        pearson_corr = pearson(a, b, c, d)
+        pearson_corr = pearson_corr(a, b, c, d, self.__device)
 
         return scc, pearson_corr
 

--- a/pysc/stream.py
+++ b/pysc/stream.py
@@ -90,9 +90,9 @@ class SCStream:
         a, b, c, d = find_corr_mat(self.__stream, other.__stream, self.__device)
 
         scc = sc_corr(a, b, c, d, self.__precision, self.__device)
-        pearson_corr = pearson_corr(a, b, c, d, self.__device)
+        psc = pearson_corr(a, b, c, d, self.__device)
 
-        return scc, pearson_corr
+        return scc, psc
 
     @property
     def _stream(self):

--- a/pysc/stream.py
+++ b/pysc/stream.py
@@ -5,7 +5,13 @@ import cupy as cp
 import numpy as np
 
 from pysc.ops import find_corr_mat, pearson, sc_corr
-from pysc.utils import ARRAY, createProbabilityStream, npStream
+from pysc.utils import (
+    ARRAY,
+    cpStream,
+    createProbabilityStream,
+    npStream,
+    shuffle_along_axis_cp,
+)
 
 
 def to_device(x: ARRAY, device):
@@ -53,17 +59,16 @@ class SCStream:
         )
         probStream *= self.__precision
 
-        if self.__device == "cpu":
-            probStream = probStream.astype(np.int32)
-        else:
-            probStream = cp.asnumpy(probStream).astype(np.int32)
-            cp.cuda.Stream.null.synchronize()
+        probStream = probStream.astype(np.int32)
 
-        self.__stream = np.zeros(inp.shape + (self.__precision,), dtype=np.bool)
-        npStream(probStream, self.__stream)
+        self.__stream = self.xp.zeros(inp.shape + (self.__precision,), dtype=np.bool)
+        if self.__device == "cpu":
+            npStream(probStream, self.__stream)
+        else:
+            cpStream(probStream, self.__stream, self.__stream)
 
         if self.__device != "cpu":
-            self.__stream = cp.array(self.__stream)
+            shuffle_along_axis_cp(self.__stream, self.ndim - 1)
             cp.cuda.Stream.null.synchronize()
 
     def to_device(self, device):

--- a/pysc/utils.py
+++ b/pysc/utils.py
@@ -36,13 +36,6 @@ def npStream(n_ones: ARRAY, out: ARRAY):
     np.random.shuffle(out)
 
 
-@guvectorize(
-    "void(int32, boolean[:], boolean[:])", "(),(n)->(n)", target="cuda", nopython=True
-)
-def cpStream(n_ones: ARRAY, _, out: ARRAY):
-    out[:n_ones] = 1
-
-
-def shuffle_along_axis_cp(a, axis):
-    idx = cp.random.rand(*a.shape).argsort(axis=axis)
-    return cp.take_along_axis(a, idx, axis=axis)
+# @guvectorize("void(int32, boolean[:], boolean[:])", "(),(n)->(n)", target='cuda', nopython=True)
+# def cpStream(n_ones: ARRAY, _, out: ARRAY):
+#     out[:n_ones] = 1

--- a/pysc/utils.py
+++ b/pysc/utils.py
@@ -36,6 +36,13 @@ def npStream(n_ones: ARRAY, out: ARRAY):
     np.random.shuffle(out)
 
 
-# @guvectorize("void(int32, boolean[:], boolean[:])", "(),(n)->(n)", target='cuda', nopython=True)
-# def cpStream(n_ones: ARRAY, _, out: ARRAY):
-#     out[:n_ones] = 1
+@guvectorize(
+    "void(int32, boolean[:], boolean[:])", "(),(n)->(n)", target="cuda", nopython=True
+)
+def cpStream(n_ones: ARRAY, _, out: ARRAY):
+    out[:n_ones] = 1
+
+
+def shuffle_along_axis_cp(a, axis):
+    idx = cp.random.rand(*a.shape).argsort(axis=axis)
+    return cp.take_along_axis(a, idx, axis=axis)

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -74,7 +74,7 @@ def test_stream_corr_cuda(starter_values):
     assert np.all(starter_values["expected_scc_cp"] == scc)
 
 
-def test_sc_corr_test(starter_values):
+def test_sc_corr(starter_values):
     xvals = starter_values["xvals"]
     yvals = starter_values["yvals"]
 
@@ -85,7 +85,7 @@ def test_sc_corr_test(starter_values):
     assert np.array_equal(starter_values["expected_scc"], sc_corrs)
 
 
-def test_combined_corr_test_cuda(starter_values):
+def test_sc_corr_cuda(starter_values):
     xvals = starter_values["xvals_cuda"]
     yvals = starter_values["yvals_cuda"]
 

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -2,11 +2,8 @@ import cupy as cp
 import numpy as np
 import pytest
 
-from pysc.ops import find_corr_mat, sc_corr
+from pysc.ops import find_corr_mat, pearson_corr, sc_corr
 from pysc.stream import SCStream
-
-
-# TODO: Complete the tests. Add for n-dim arrays. Add specific for cupy arrays
 
 
 @pytest.fixture
@@ -55,32 +52,38 @@ def test_stream_corr(starter_values):
     sc_one._stream = xvals
     sc_two._stream = yvals
 
-    scc, _ = sc_one.corr_with(sc_two)
+    scc, psc = sc_one.corr_with(sc_two)
+    psc.round(2, out=psc)
 
     assert np.array_equal(starter_values["expected_scc"], scc)
+    assert np.allclose(starter_values["expected_pearson"], psc)
 
 
 def test_stream_corr_cuda(starter_values):
     xvals, yvals = starter_values["xvals_cuda"], starter_values["yvals_cuda"]
+    device = "gpu"
 
-    sc_one = SCStream(np.zeros(xvals.shape[0], dtype=np.float32), device="gpu")
-    sc_two = SCStream(np.zeros(yvals.shape[0], dtype=np.float32), device="gpu")
+    sc_one = SCStream(np.zeros(xvals.shape[0], dtype=np.float32), device=device)
+    sc_two = SCStream(np.zeros(yvals.shape[0], dtype=np.float32), device=device)
 
     sc_one._stream = xvals
     sc_two._stream = yvals
 
-    scc, _ = sc_one.corr_with(sc_two)
+    scc, psc = sc_one.corr_with(sc_two)
+    psc.round(2, out=psc)
 
     assert np.all(starter_values["expected_scc_cp"] == scc)
+    assert np.allclose(starter_values["expected_pearson"], psc)
 
 
 def test_sc_corr(starter_values):
     xvals = starter_values["xvals"]
     yvals = starter_values["yvals"]
+    device = "cpu"
 
-    a, b, c, d = find_corr_mat(xvals, yvals, "cpu")
+    a, b, c, d = find_corr_mat(xvals, yvals, device)
 
-    sc_corrs = sc_corr(a, b, c, d, xvals.shape[1], "cpu")
+    sc_corrs = sc_corr(a, b, c, d, xvals.shape[1], device)
 
     assert np.array_equal(starter_values["expected_scc"], sc_corrs)
 
@@ -88,9 +91,36 @@ def test_sc_corr(starter_values):
 def test_sc_corr_cuda(starter_values):
     xvals = starter_values["xvals_cuda"]
     yvals = starter_values["yvals_cuda"]
+    device = "gpu"
 
-    a, b, c, d = find_corr_mat(xvals, yvals, "gpu")
+    a, b, c, d = find_corr_mat(xvals, yvals, device)
 
-    sc_corrs = sc_corr(a, b, c, d, xvals.shape[1], "gpu")
+    sc_corrs = sc_corr(a, b, c, d, xvals.shape[1], device)
 
     assert np.all(starter_values["expected_scc_cp"] == sc_corrs)
+
+
+def test_sc_corr(starter_values):
+    xvals = starter_values["xvals"]
+    yvals = starter_values["yvals"]
+    device = "cpu"
+
+    a, b, c, d = find_corr_mat(xvals, yvals, device)
+
+    pearson_corrs = pearson_corr(a, b, c, d, device)
+    pearson_corrs.round(2, out=pearson_corrs)
+
+    assert np.allclose(starter_values["expected_pearson"], pearson_corrs)
+
+
+def test_sc_corr(starter_values):
+    xvals = starter_values["xvals_cuda"]
+    yvals = starter_values["yvals_cuda"]
+    device = "gpu"
+
+    a, b, c, d = find_corr_mat(xvals, yvals, device)
+
+    pearson_corrs = pearson_corr(a, b, c, d, device)
+    pearson_corrs.round(2, out=pearson_corrs)
+
+    assert np.allclose(starter_values["expected_pearson"], pearson_corrs)

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -13,7 +13,7 @@ def base_arrays():
 
 
 def test_scstream_init_default(base_arrays):
-    stream = SCStream(base_arrays[0], -1.2, 1.0)
+    stream = SCStream(base_arrays[0])
 
     assert isinstance(stream.min_val, int)
     assert isinstance(stream.max_val, int)


### PR DESCRIPTION
- Change stream creation pipeline (adding 'create_probability_stream'  as an intermediate step)
- Add support for UPE streams
- Turn precision and device into properties instead of attributes

Note: Streams are now created on CPU and moved to GPU if necessary. This behaviour may change if better ways of shuffling streams are found.